### PR TITLE
Update tank_types.dm

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -16,7 +16,7 @@
 	desc = "A tank of oxygen."
 	icon_state = "oxygen"
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
-	starting_pressure = list("oxygen" = 6*ONE_ATMOSPHERE)
+	starting_pressure = list("oxygen" = 10*ONE_ATMOSPHERE)
 	volume = 180
 
 /obj/item/weapon/tank/oxygen/yellow
@@ -36,8 +36,9 @@
 	desc = "A tank with an N2O/O2 gas mix."
 	icon_state = "anesthetic"
 	item_state = "an_tank"
-	starting_pressure = list("oxygen" = 6*ONE_ATMOSPHERE*O2STANDARD, "sleeping_agent" = 6*ONE_ATMOSPHERE*N2STANDARD)
-	volume = 270
+	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
+	starting_pressure = list("oxygen" = 10*ONE_ATMOSPHERE*O2STANDARD, "sleeping_agent" = 10*ONE_ATMOSPHERE*N2STANDARD)
+	volume = 180
 
 /*
  * Air


### PR DESCRIPTION
Oxygen tanks (full size) now has a full 10xpressure in it by default.
Anesthetic:
* Now start full
* Modified volume to match default tanks instead of being super meta by having a higher potential volume
* Hopefully won't explode
* Defaults to a distribute pressure so people won't suffocate automatically when you try using it on them
Discovered:
Despite having 6xpressure for two gasses and 6xpressure for one gas in two separate tanks, when in game they spawn having identical total volumes of gas (variation of .01 kpa). The anasthetic has less oxygen in proportion, and the oxygen having fewer moles in the same tank. Something extremely screwy is going on.